### PR TITLE
Fix Markdown desired version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
         "Topic :: Text Processing :: Filters",
         "Topic :: Text Processing :: Markup :: HTML",
     ],
-    install_requires=["markdown>=2.6.8", "pygments"],
+    install_requires=["markdown>=2.6.8,<3.0", "pygments"],
 )


### PR DESCRIPTION
This changeset avoid Markdown 3.x version to be installed. The
mdtree is compatible with Markdown 2.6.x versions.